### PR TITLE
Use secure extension workaround on Mi A1 instead of overriding the de…

### DIFF
--- a/src/main/java/com/theoplayer/android/decoderselector/ExternalDecoderSelectionHelper.kt
+++ b/src/main/java/com/theoplayer/android/decoderselector/ExternalDecoderSelectionHelper.kt
@@ -6,17 +6,17 @@ import com.theoplayer.android.api.settings.DecoderSelectionHelper
 import com.theoplayer.android.api.settings.DecoderType
 
 class ExternalDecoderSelectionHelper : DecoderSelectionHelper() {
-    override fun shouldUseDecoder(
+    override fun shouldApplySecureExtensionWorkaround(
         decoderType: DecoderType?,
         decoderName: String?,
         codecInfo: MediaCodecInfo?
     ): Boolean {
 
         // Xiaomi Mi A1
-        if ("OMX.qcom.video.decoder.avc" == decoderName && "tissot" == Build.PRODUCT){
-            return false
+        if ("OMX.qcom.video.decoder.avc" == decoderName && "tissot" == Build.PRODUCT) {
+            return true
         }
 
-        return super.shouldUseDecoder(decoderType, decoderName, codecInfo)
+        return super.shouldApplySecureExtensionWorkaround(decoderType, decoderName, codecInfo)
     }
 }

--- a/src/test/java/com/theoplayer/android/decoderselector/ExternalDecoderSelectionHelperTest.kt
+++ b/src/test/java/com/theoplayer/android/decoderselector/ExternalDecoderSelectionHelperTest.kt
@@ -29,9 +29,16 @@ class ExternalDecoderSelectionHelperTest {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "randomDevice")
         assertTrue(decoderSelectionHelper.shouldUseDecoder(DecoderType.VIDEO, "randomDecoder", null))
     }
+
     @Test
-    fun xiaomiM1_isDecoderSelectionFixed() {
+    fun randomDevice_withRandomDecoder_isSecureExtensionWorkaroundCallingSuper() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "randomDevice")
+        assertFalse(decoderSelectionHelper.shouldApplySecureExtensionWorkaround(DecoderType.VIDEO, "randomDecoder", null))
+    }
+
+    @Test
+    fun xiaomiM1_isSecureExtensionWorkaroundApplied() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "tissot")
-        assertFalse(decoderSelectionHelper.shouldUseDecoder(DecoderType.VIDEO, "OMX.qcom.video.decoder.avc", null))
+        assertTrue(decoderSelectionHelper.shouldApplySecureExtensionWorkaround(DecoderType.VIDEO, "OMX.qcom.video.decoder.avc", null))
     }
 }


### PR DESCRIPTION
Overriding the decoder on Xiaomi Mi A1 devices causes the player to lag. The secure extension workaround should be applied instead to fix the DRM issues without causing the lag.